### PR TITLE
Redfish: Add hostswap reset

### DIFF
--- a/redfish-core/include/redfish.hpp
+++ b/redfish-core/include/redfish.hpp
@@ -79,6 +79,7 @@ class RedfishService
         nodes.emplace_back(std::make_unique<Power>(app));
         nodes.emplace_back(std::make_unique<ChassisCollection>(app));
         nodes.emplace_back(std::make_unique<Chassis>(app));
+        nodes.emplace_back(std::make_unique<ChassisActionsReset>(app));
         nodes.emplace_back(std::make_unique<UpdateService>(app));
         nodes.emplace_back(std::make_unique<StorageCollection>(app));
         nodes.emplace_back(std::make_unique<Storage>(app));


### PR DESCRIPTION
Hostswap reset by using Redfish

Usage:
  POST on /redfish/v1/Chassis/chassis/Actions/Chassis.Reset/
  {
    "ResetType": "PowerCycle"
  }

Change-Id: I4c3a5889f9ce4c93bbdaa9f669a426b833e1cfc7
Signed-off-by: P.K. Lee <p.k.lee@quantatw.com>